### PR TITLE
Update links to from old repo to new

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tipsi/tipsi_appium.git"
+    "url": "git+https://github.com/tipsi/tipsi-appium-helper.git"
   },
   "keywords": [
     "appium",
@@ -25,9 +25,9 @@
   "author": "Tipsi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tipsi/tipsi_appium/issues"
+    "url": "https://github.com/tipsi/tipsi-appium-helper/issues"
   },
-  "homepage": "https://github.com/tipsi/tipsi_appium#readme",
+  "homepage": "https://github.com/tipsi/tipsi-appium-helper#readme",
   "dependencies": {
     "adbkit": "^2.6.0",
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Hi, guys! I found incorrect links to repo on package.json. Just updated them:
![image](https://cloud.githubusercontent.com/assets/1788245/21671245/1a71784c-d32b-11e6-8abd-fd5be2a31210.png)
