### PR TITLE
Fix wrong sort of sdk's in node-simctl module

### DIFF
--- a/__tests__/core/configuration.js
+++ b/__tests__/core/configuration.js
@@ -11,6 +11,7 @@ group('configuration', (test) => {
   }
 
   test('default', (t) => {
+    const env = pmock.env({})
     const result = configure()
 
     t.deepLooseEqual(
@@ -18,6 +19,8 @@ group('configuration', (test) => {
       defaultConfig,
       'Result should contain default configuration'
     )
+
+    env.reset()
   })
 
   test('enviroment', (t) => {
@@ -52,6 +55,7 @@ group('configuration', (test) => {
       appPath: './app.apk',
       noReset: true,
     }
+    const env = pmock.env({})
     const expectedResult = {
       ...defaultConfig,
       ...optionsConfig,
@@ -63,9 +67,12 @@ group('configuration', (test) => {
       expectedResult,
       'Result should contain values from passed options'
     )
+
+    env.reset()
   })
 
   test('file', (t) => {
+    const env = pmock.env({})
     const pathToRCFile = path.resolve('__tests__/mock/.appiumhelperrc')
     const baseConfig = {
       ...defaultConfig,
@@ -102,6 +109,8 @@ group('configuration', (test) => {
       androidExpectedConfig,
       'Result should contain values from file and use Android specific values'
     )
+
+    env.reset()
   })
 
   test('priority', (t) => {

--- a/__tests__/mock/simctl.js
+++ b/__tests__/mock/simctl.js
@@ -1,44 +1,4 @@
 const devices = {
-  '8.1': [{ // eslint-disable-line quote-props
-    name: 'iPhone 4s',
-    udid: 'EE2E9F08-7507-493D-A412-831169DC0E6C',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, {
-    name: 'iPhone 5',
-    udid: '01D4A739-E576-4716-89A0-1D8D2F616FB8',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, {
-    name: 'iPhone 5s',
-    udid: 'CCA15405-1BF2-4FE9-BA04-7F1731F8BC27',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, {
-    name: 'iPhone 6',
-    udid: '44282DB9-2FD5-4388-9899-3E897193D79F',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, {
-    name: 'iPhone 6 Plus',
-    udid: '782001DA-B562-4063-9C8D-0B076DB8C9AA',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, {
-    name: 'iPad 2',
-    udid: '129A7CE2-195F-4B40-94BF-6F53298D7501',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, {
-    name: 'iPad Retina',
-    udid: 'F0C3DC79-AE98-478D-AE5A-485AED2C7B5C',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }, { name: 'iPad Air',
-    udid: '2CF06B47-0765-44E3-B1FA-D54CD6BB5322',
-    state: 'Shutdown',
-    sdk: '8.1',
-  }],
   '10.2': [{ // eslint-disable-line quote-props
     name: 'iPhone 5',
     udid: '72C380C0-77BD-4E78-B5DF-010A46CEDA69',
@@ -129,6 +89,46 @@ const devices = {
     udid: 'C305142C-781B-4CC3-A98F-5178A09C50F4',
     state: 'Shutdown',
     sdk: '10.2',
+  }],
+  '8.1': [{ // eslint-disable-line quote-props
+    name: 'iPhone 4s',
+    udid: 'EE2E9F08-7507-493D-A412-831169DC0E6C',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, {
+    name: 'iPhone 5',
+    udid: '01D4A739-E576-4716-89A0-1D8D2F616FB8',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, {
+    name: 'iPhone 5s',
+    udid: 'CCA15405-1BF2-4FE9-BA04-7F1731F8BC27',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, {
+    name: 'iPhone 6',
+    udid: '44282DB9-2FD5-4388-9899-3E897193D79F',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, {
+    name: 'iPhone 6 Plus',
+    udid: '782001DA-B562-4063-9C8D-0B076DB8C9AA',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, {
+    name: 'iPad 2',
+    udid: '129A7CE2-195F-4B40-94BF-6F53298D7501',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, {
+    name: 'iPad Retina',
+    udid: 'F0C3DC79-AE98-478D-AE5A-485AED2C7B5C',
+    state: 'Shutdown',
+    sdk: '8.1',
+  }, { name: 'iPad Air',
+    udid: '2CF06B47-0765-44E3-B1FA-D54CD6BB5322',
+    state: 'Shutdown',
+    sdk: '8.1',
   }],
 }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "semver-compare": "^1.0.0",
     "tap-diff": "^0.1.1",
     "tape": "^4.6.2",
-    "version-sort": "^0.1.1",
     "webdriverio": "^4.2.16"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "semver-compare": "^1.0.0",
     "tap-diff": "^0.1.1",
     "tape": "^4.6.2",
+    "version-sort": "^0.1.1",
     "webdriverio": "^4.2.16"
   },
   "devDependencies": {

--- a/src/core/find-ios-device.js
+++ b/src/core/find-ios-device.js
@@ -1,10 +1,10 @@
 import { getDevices } from 'node-simctl'
-import versionSort from 'version-sort'
+import cmp from 'semver-compare'
 
 export default async function findiOSDevice(type = 'iPhone 6', version) {
   const result = await getDevices()
 
-  const sdks = versionSort(Object.keys(result))
+  const sdks = Object.keys(result).sort(cmp)
   const devices = sdks.reduce(
     (memo, sdk) => {
       const nextDevices = result[sdk].map(

--- a/src/core/find-ios-device.js
+++ b/src/core/find-ios-device.js
@@ -1,9 +1,10 @@
 import { getDevices } from 'node-simctl'
+import versionSort from 'version-sort'
 
 export default async function findiOSDevice(type = 'iPhone 6', version) {
   const result = await getDevices()
 
-  const sdks = Object.keys(result)
+  const sdks = versionSort(Object.keys(result))
   const devices = sdks.reduce(
     (memo, sdk) => {
       const nextDevices = result[sdk].map(


### PR DESCRIPTION
Now `node-simctl` returns sdk\`s without sort. It is sometimes breaks `find-ios-device` logic.
I added sorting and updated tests for `find-ios-device` method.