### PR TITLE
Set webdriverio as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-appium-helper",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Tipsi Appium Helper",
   "main": "src/index.js",
   "bin": {
@@ -28,6 +28,9 @@
     "url": "https://github.com/tipsi/tipsi-appium-helper/issues"
   },
   "homepage": "https://github.com/tipsi/tipsi-appium-helper#readme",
+  "peerDependencies": {
+    "webdriverio": ">= 4.2 < 5.0"
+  },
   "dependencies": {
     "adbkit": "^2.6.0",
     "await-repl": "^1.0.2",
@@ -48,8 +51,7 @@
     "resolve": "^1.2.0",
     "semver-compare": "^1.0.0",
     "tap-diff": "^0.1.1",
-    "tape": "^4.6.2",
-    "webdriverio": "^4.2.16"
+    "tape": "^4.6.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",
@@ -61,6 +63,7 @@
     "eslint-plugin-react": "^6.3.0",
     "nock": "^9.0.2",
     "pmock": "^0.2.3",
-    "tape-plus": "^1.0.0"
+    "tape-plus": "^1.0.0",
+    "webdriverio": "^4.2.16"
   }
 }


### PR DESCRIPTION
We have some problems with protocol deviation between `appium` and the new version of `webdriverio`. I think it is better to allow to specify the own version of `webdriverio`.