### PR TITLE
[2.1.3] Remove logLevel 'debug'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - "8"
   - "9"
-  - "10"
 script:
-  - npm run test
+  - npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-appium-helper",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Tipsi Appium Helper",
   "main": "src/index.js",
   "bin": {

--- a/src/helper.js
+++ b/src/helper.js
@@ -25,7 +25,6 @@ class Helper {
         automationName: config.automationName,
         newCommandTimeout: 60000,
       },
-      logLevel: 'debug',
       path: '/wd/hub',
       host: config.appiumHost,
       port: config.appiumPort,


### PR DESCRIPTION
We are don't use any debug level from the start of our journey.
A newer version of `webdriverio` just breaks the process when a level is incorrect.
So, just use a default level from `webdriverio` itself.