### PR TITLE
 Adds a unique id to driver source output XML filenames to prevent overwrites

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-appium-helper",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Tipsi Appium Helper",
   "main": "src/index.js",
   "bin": {

--- a/src/plugins/source.js
+++ b/src/plugins/source.js
@@ -1,11 +1,12 @@
 import path from 'path'
 import fs from 'fs'
+import _ from 'lodash'
 
 export default async function () {
   const content = await this.driver.getSource()
 
   return new Promise((resolve) => {
-    const pathToLog = path.resolve(process.cwd(), 'appium_source.xml')
+    const pathToLog = path.resolve(process.cwd(), _.uniqueId('appium_source_')+'.xml')
     fs.writeFile(pathToLog, content, 'utf8', (error) => {
       if (error) {
         console.log('---------------------------------------------------')


### PR DESCRIPTION
When there are multiple test failures, this change will save each captured source to a separate file.